### PR TITLE
Publish Kafka events for orders

### DIFF
--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 
     runtimeOnly("org.postgresql:postgresql")

--- a/order-service/src/main/java/com/minicommerce/orders/config/KafkaConfig.java
+++ b/order-service/src/main/java/com/minicommerce/orders/config/KafkaConfig.java
@@ -1,0 +1,32 @@
+package com.minicommerce.orders.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory(KafkaProperties props) {
+        Map<String, Object> cfg = new HashMap<>(props.buildProducerProperties());
+        cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(cfg);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> pf) {
+        return new KafkaTemplate<>(pf);
+    }
+
+}

--- a/order-service/src/main/java/com/minicommerce/orders/events/EventPublisher.java
+++ b/order-service/src/main/java/com/minicommerce/orders/events/EventPublisher.java
@@ -1,0 +1,26 @@
+package com.minicommerce.orders.events;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventPublisher {
+    private final KafkaTemplate<String, Object> kafka;
+
+    public EventPublisher(KafkaTemplate<String, Object> kafka) {
+        this.kafka = kafka;
+    }
+
+    public void publish(String topic, String key, Object payload) {
+        RuntimeException last = null;
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            try {
+                kafka.send(topic, key, payload).get();
+                return;
+            } catch (Exception e) {
+                last = new RuntimeException("Failed to publish to %s (attempt %d)".formatted(topic, attempt), e);
+            }
+        }
+        throw last;
+    }
+}

--- a/order-service/src/main/java/com/minicommerce/orders/events/OrderCancelledEvent.java
+++ b/order-service/src/main/java/com/minicommerce/orders/events/OrderCancelledEvent.java
@@ -1,0 +1,12 @@
+package com.minicommerce.orders.events;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record OrderCancelledEvent(
+        String type,
+        String version,
+        UUID orderId,
+        OffsetDateTime cancelledAt,
+        String reason
+) {}

--- a/order-service/src/main/java/com/minicommerce/orders/events/OrderCreatedEvent.java
+++ b/order-service/src/main/java/com/minicommerce/orders/events/OrderCreatedEvent.java
@@ -1,0 +1,19 @@
+package com.minicommerce.orders.events;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCreatedEvent(
+        String type,
+        String version,
+        UUID orderId,
+        UUID customerId,
+        String currency,
+        BigDecimal total,
+        OffsetDateTime createdAt,
+        List<Item> items
+) {
+    public static record Item(String sku, String name, int quantity, BigDecimal unitPrice) {}
+}

--- a/order-service/src/main/java/com/minicommerce/orders/events/Topics.java
+++ b/order-service/src/main/java/com/minicommerce/orders/events/Topics.java
@@ -1,0 +1,7 @@
+package com.minicommerce.orders.events;
+
+public final class Topics {
+    private Topics() {}
+    public static final String ORDER_CREATED = "mini.order.created.v1";
+    public static final String ORDER_CANCELLED = "mini.order.cancelled.v1";
+}

--- a/order-service/src/test/java/com/minicommerce/orders/events/EventPublisherTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/events/EventPublisherTest.java
@@ -1,0 +1,44 @@
+package com.minicommerce.orders.events;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EventPublisherTest {
+
+    @Test
+    void retries_on_failure() {
+        KafkaTemplate<String, Object> kafka = Mockito.mock(KafkaTemplate.class);
+        EventPublisher publisher = new EventPublisher(kafka);
+
+        CompletableFuture<SendResult<String, Object>> fail = new CompletableFuture<>();
+        fail.completeExceptionally(new RuntimeException("fail"));
+        CompletableFuture<SendResult<String, Object>> success = new CompletableFuture<>();
+        success.complete(null);
+
+        Mockito.when(kafka.send(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(fail, fail, success);
+
+        publisher.publish("t", "k", new Object());
+        Mockito.verify(kafka, Mockito.times(3)).send(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+    }
+
+    @Test
+    void throws_after_max_attempts() {
+        KafkaTemplate<String, Object> kafka = Mockito.mock(KafkaTemplate.class);
+        EventPublisher publisher = new EventPublisher(kafka);
+
+        CompletableFuture<SendResult<String, Object>> fail = new CompletableFuture<>();
+        fail.completeExceptionally(new RuntimeException("fail"));
+        Mockito.when(kafka.send(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(fail);
+
+        assertThrows(RuntimeException.class, () -> publisher.publish("t", "k", new Object()));
+        Mockito.verify(kafka, Mockito.times(3)).send(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+    }
+}

--- a/order-service/src/test/java/com/minicommerce/orders/service/OrderServiceEventPublishingTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/service/OrderServiceEventPublishingTest.java
@@ -1,0 +1,97 @@
+package com.minicommerce.orders.service;
+
+import com.minicommerce.orders.events.EventPublisher;
+import com.minicommerce.orders.events.OrderCreatedEvent;
+import com.minicommerce.orders.events.Topics;
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Testcontainers
+class OrderServiceEventPublishingTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void datasourceProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.flyway.enabled", () -> "false");
+    }
+
+    @Autowired
+    OrderService service;
+    @Autowired
+    OrderRepository orders;
+    @MockBean
+    EventPublisher publisher;
+
+    CreateOrderRequest request;
+
+    @BeforeEach
+    void setup() {
+        orders.deleteAll();
+        request = new CreateOrderRequest(
+                UUID.randomUUID(),
+                "USD",
+                List.of(new OrderItemRequest("SKU1", "Mouse", 1, new BigDecimal("10.00")))
+        );
+    }
+
+    @Test
+    void create_publishes_event_after_commit() {
+        service.create(request);
+
+        ArgumentCaptor<OrderCreatedEvent> event = ArgumentCaptor.forClass(OrderCreatedEvent.class);
+        Mockito.verify(publisher).publish(Mockito.eq(Topics.ORDER_CREATED), Mockito.anyString(), event.capture());
+        assertThat(event.getValue().type()).isEqualTo("order.created");
+        assertThat(event.getValue().version()).isEqualTo("v1");
+    }
+
+    @Test
+    void create_throws_when_publish_fails_but_order_persisted() {
+        Mockito.doThrow(new RuntimeException("kafka down"))
+                .when(publisher).publish(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+
+        assertThrows(RuntimeException.class, () -> service.create(request));
+        assertEquals(1, orders.count());
+    }
+
+    @Test
+    void cancel_publishes_event() {
+        service.create(request);
+        Mockito.reset(publisher);
+
+        var order = orders.findAll().get(0);
+        service.cancel(order.getId());
+
+        Mockito.verify(publisher)
+                .publish(Mockito.eq(Topics.ORDER_CANCELLED),
+                        Mockito.eq(order.getId().toString()),
+                        Mockito.any());
+    }
+}


### PR DESCRIPTION
## Summary
- add Kafka dependencies and config
- publish `order.created` and `order.cancelled` events after transactions commit
- include retry-aware `EventPublisher` and comprehensive tests
- run database tests against PostgreSQL via Testcontainers