### PR TITLE
Feat: outbox events

### DIFF
--- a/docs/api/events/order.cancelled.v1.json
+++ b/docs/api/events/order.cancelled.v1.json
@@ -1,17 +1,28 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mini-commerce.local/schemas/order.cancelled.v1.json",
-  "title": "order.cancelled.v1",
+  "title": "order.cancelled.v1 envelope",
   "type": "object",
   "additionalProperties": false,
-  "required": ["orderId", "cancelledAt"],
+  "required": ["eventId", "type", "version", "occurredAt", "aggregateType", "aggregateId", "data"],
   "properties": {
-    "orderId": { "type": "string", "format": "uuid" },
-    "cancelledAt": { "type": "string", "format": "date-time" },
-    "reason": { "type": ["string", "null"], "maxLength": 256 },
+    "eventId": { "type": "string", "format": "uuid" },
     "type": { "type": "string", "const": "order.cancelled" },
-    "version": { "type": "string", "const": "1" }
+    "version": { "type": "string", "const": "v1" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "aggregateType": { "type": "string", "const": "order" },
+    "aggregateId": { "type": "string", "format": "uuid" },
+    "traceId": { "type": "string" },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["orderId", "cancelledAt"],
+      "properties": {
+        "orderId": { "type": "string", "format": "uuid" },
+        "cancelledAt": { "type": "string", "format": "date-time" },
+        "reason": { "type": ["string", "null"], "maxLength": 256 }
+      }
+    }
   },
-  "description": "Canonical order.cancelled event (minimal) prior to envelope adoption."
+  "description": "Envelope + data payload for order.cancelled.v1 after transactional outbox adoption"
 }
-

--- a/docs/api/events/order.created.v1.json
+++ b/docs/api/events/order.created.v1.json
@@ -1,34 +1,45 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mini-commerce.local/schemas/order.created.v1.json",
-  "title": "order.created.v1",
+  "title": "order.created.v1 envelope",
   "type": "object",
   "additionalProperties": false,
-  "required": ["orderId", "customerId", "items", "currency", "total", "createdAt"],
+  "required": ["eventId", "type", "version", "occurredAt", "aggregateType", "aggregateId", "data"],
   "properties": {
-    "orderId": { "type": "string", "format": "uuid" },
-    "customerId": { "type": "string", "format": "uuid" },
-    "items": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "required": ["sku", "name", "quantity", "unitPrice"],
-        "properties": {
-          "sku": { "type": "string", "minLength": 1 },
-          "name": { "type": "string", "minLength": 1 },
-          "quantity": { "type": "integer", "minimum": 1 },
-          "unitPrice": { "type": "number", "minimum": 0 }
+    "eventId": { "type": "string", "format": "uuid" },
+    "type": { "type": "string", "const": "order.created" },
+    "version": { "type": "string", "const": "v1" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "aggregateType": { "type": "string", "const": "order" },
+    "aggregateId": { "type": "string", "format": "uuid" },
+    "traceId": { "type": "string" },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["orderId", "customerId", "items", "currency", "total", "createdAt"],
+      "properties": {
+        "orderId": { "type": "string", "format": "uuid" },
+        "customerId": { "type": "string", "format": "uuid" },
+        "items": {
+          "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["sku", "name", "quantity", "unitPrice"],
+              "additionalProperties": false,
+              "properties": {
+                "sku": { "type": "string", "minLength": 1 },
+                "name": { "type": "string", "minLength": 1 },
+                "quantity": { "type": "integer", "minimum": 1 },
+                "unitPrice": { "type": "number", "minimum": 0 }
+              }
+            }
         },
-        "additionalProperties": false
+        "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+        "total": { "type": "number", "minimum": 0 },
+        "createdAt": { "type": "string", "format": "date-time" }
       }
-    },
-    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
-    "total": { "type": "number", "minimum": 0 },
-    "createdAt": { "type": "string", "format": "date-time" },
-    "type": { "type": "string", "const": "order.created", "description": "(Future envelope field)" },
-    "version": { "type": "string", "const": "1", "description": "(Future envelope field)" }
+    }
   },
-  "description": "Canonical order.created event (current minimal payload; envelope fields optional until outbox/envelope rollout)."
+  "description": "Envelope + data payload for order.created.v1 after transactional outbox adoption"
 }
-

--- a/docs/task-status-template.md
+++ b/docs/task-status-template.md
@@ -1,0 +1,146 @@
+# 🛠 Task Status Template
+
+> Timestamp: {{YYYY-MM-DD}}
+> Owner: {{Name / Squad}}
+> Objective: {{Concise, outcome-focused statement}}
+
+---
+## 🎯 Why This Matters
+Brief business / architectural justification. What risk or gap are we closing? What value / narrative (portfolio, reliability, etc.) is improved?
+
+---
+## 🗺 High-Level Plan
+1. {{Step 1}}
+2. {{Step 2}}
+3. {{Step 3}}
+4. {{Stretch / Optional}}
+
+---
+## 🧱 Scope (In / Out)
+| Area | In Scope | Deferred |
+|------|----------|----------|
+| Reliability | {{Yes}} | {{Out-of-scope items}} |
+| Schema / Contracts | {{}} | {{}} |
+| Observability | {{}} | {{}} |
+| Domain Model | {{}} | {{}} |
+| Resilience | {{}} | {{}} |
+| Ops / Admin | {{}} | {{}} |
+
+---
+## 📦 Deliverables Status
+List concrete artifacts (code units, docs, migrations). Use emoji legend below.
+- 🟢 {{Example Deliverable Done}}
+- 🟡 {{In Progress Deliverable}}
+- 🔴 {{Not Started Deliverable}}
+
+---
+## ✅ Status Legend
+| Emoji | Meaning |
+|-------|---------|
+| 🟢 | Done |
+| 🟡 | In Progress / Partial |
+| 🔴 | Not Started |
+| 🧪 | Testing / Verifying |
+| 📌 | Blocked / Decision Needed |
+
+---
+## 📋 Task Board
+### 1. {{Category A}}
+- 🔴 {{Task}}
+- 🟡 {{Task}}
+
+### 2. {{Category B}}
+- 🔴 {{Task}}
+
+### 3. {{Category C}}
+- 🔴 {{Task}}
+
+(Replicate categories as needed: Core Impl, Reliability, Domain, Tests, Metrics, Docs, Stretch)
+
+---
+## 🧪 Test Matrix
+| Test Name | Category | Purpose | Status |
+|-----------|----------|---------|--------|
+| {{test_create}} | Integration | Ensures X | 🔴 |
+| {{test_validation}} | Unit | Rejects invalid input | 🔴 |
+| {{test_retry}} | Integration | Retry logic works | 🔴 |
+
+---
+## 🔐 Design Notes
+Bullets summarizing patterns / constraints:
+- Pattern: {{Transactional Outbox / Saga / CQRS}}
+- Backoff: {{formula}}
+- Serialization: {{JSON / Avro}}
+- Idempotency: {{Key derivation}}
+
+---
+## ⚠ Risks & Mitigations
+| Risk | Impact | Mitigation | Owner |
+|------|--------|-----------|-------|
+| {{Risk}} | {{High/Med/Low}} | {{Mitigation}} | {{}} |
+
+---
+## 📊 Metrics (Planned)
+List metric names early for consistency.
+- {{service.outbox.pending}}
+- {{service.latency.ms}}
+- {{domain.event.publish.attempt{status}}}
+
+---
+## 🧵 Trace & Correlation
+How traceId / correlationId flows, any headers, propagation gaps.
+
+---
+## ⏭ Next Sprint Focus
+1. {{Immediate next actionable}}
+2. {{Secondary}}
+3. {{Stretch}}
+
+---
+## 🔄 Progress Log
+| Time | Action | Notes |
+|------|--------|-------|
+| {{YYYY-MM-DD}} | Created | Initial scaffold |
+| {{YYYY-MM-DD}} | Update | {{Milestone}} |
+
+---
+## 📥 Dependencies / Libraries
+- {{lib:name}} (purpose)
+
+---
+## 🧭 Acceptance Criteria
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| {{No afterCommit}} | 🔴 | {{Link / Test}} |
+| {{Retry backoff}} | 🔴 | {{Test name}} |
+| {{Contract validated}} | 🔴 | {{Schema test}} |
+
+---
+## 📝 Example Envelope (If Event Work)
+```json
+{
+  "eventId": "...",
+  "type": "...",
+  "version": "v1",
+  "occurredAt": "...",
+  "aggregateType": "...",
+  "aggregateId": "...",
+  "traceId": "...",
+  "data": {"...": "..."}
+}
+```
+
+---
+## 📎 Pending Decisions
+| Topic | Needed By | Options | Chosen | Notes |
+|-------|-----------|---------|--------|-------|
+| {{Schema registry?}} | {{Date}} | {{A/B/C}} | {{?}} | {{}} |
+
+---
+## 📚 Appendix (Optional)
+- Sequence Diagram: `docs/diagrams/{{name}}.puml`
+- ADR References: `docs/adr/{{id}}-*.md`
+
+---
+Fill placeholders, prune unused sections, and keep concise. Keep this template versioned for consistency across services.
+

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation("org.flywaydb:flyway-core")
     testRuntimeOnly("org.postgresql:postgresql")
     testImplementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
+    testImplementation("org.awaitility:awaitility:4.2.0")
 }
 
 tasks.test {

--- a/order-service/build.gradle.kts
+++ b/order-service/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("com.networknt:json-schema-validator:1.0.86")
 
     runtimeOnly("org.postgresql:postgresql")
     implementation("org.flywaydb:flyway-core")

--- a/order-service/src/main/java/com/minicommerce/orders/OrdersApplication.java
+++ b/order-service/src/main/java/com/minicommerce/orders/OrdersApplication.java
@@ -1,9 +1,14 @@
 package com.minicommerce.orders;
 
+import com.minicommerce.orders.outbox.OutboxProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
+@EnableConfigurationProperties(OutboxProperties.class)
 public class OrdersApplication {
     public static void main(String[] args) {
         SpringApplication.run(OrdersApplication.class, args);

--- a/order-service/src/main/java/com/minicommerce/orders/domain/Order.java
+++ b/order-service/src/main/java/com/minicommerce/orders/domain/Order.java
@@ -13,6 +13,9 @@ public class Order {
     @Id
     private UUID id;
 
+    @Version
+    private Long version;
+
     @Column(name = "customer_id", nullable = false)
     private UUID customerId;
 
@@ -40,6 +43,22 @@ public class Order {
         this.items.add(item);
     }
 
+    @PrePersist
+    public void prePersist(){
+        var now = OffsetDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+        if(total == null) total = BigDecimal.ZERO;
+    }
+
+    @PreUpdate
+    public void preUpdate(){
+        updatedAt = OffsetDateTime.now();
+        if(total.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalStateException("Order total cannot be negative");
+        }
+    }
+
     // getters/setters
     public UUID getId(){ return id; }
     public void setId(UUID id){ this.id = id; }
@@ -57,4 +76,6 @@ public class Order {
     public void setUpdatedAt(OffsetDateTime updatedAt){ this.updatedAt = updatedAt; }
     public List<OrderItem> getItems(){ return items; }
     public void setItems(List<OrderItem> items){ this.items = items; }
+    public Long getVersion() { return version; }
+    public void setVersion(Long version) { this.version = version; }
 }

--- a/order-service/src/main/java/com/minicommerce/orders/events/EventEnvelope.java
+++ b/order-service/src/main/java/com/minicommerce/orders/events/EventEnvelope.java
@@ -1,0 +1,16 @@
+package com.minicommerce.orders.events;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record EventEnvelope<T>(
+        UUID eventId,
+        String type,
+        String version,
+        OffsetDateTime occurredAt,
+        String aggregateType,
+        String aggregateId,
+        String traceId,
+        T data
+) {}
+

--- a/order-service/src/main/java/com/minicommerce/orders/events/OrderCancelledEvent.java
+++ b/order-service/src/main/java/com/minicommerce/orders/events/OrderCancelledEvent.java
@@ -4,8 +4,6 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record OrderCancelledEvent(
-        String type,
-        String version,
         UUID orderId,
         OffsetDateTime cancelledAt,
         String reason

--- a/order-service/src/main/java/com/minicommerce/orders/events/OrderCreatedEvent.java
+++ b/order-service/src/main/java/com/minicommerce/orders/events/OrderCreatedEvent.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.UUID;
 
 public record OrderCreatedEvent(
-        String type,
-        String version,
         UUID orderId,
         UUID customerId,
         String currency,

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxEvent.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxEvent.java
@@ -1,0 +1,89 @@
+package com.minicommerce.orders.outbox;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "outbox_events", indexes = {
+        @Index(name = "idx_outbox_status_due", columnList = "status,next_attempt_at")
+})
+public class OutboxEvent {
+    @Id
+    private UUID id;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private String aggregateId;
+
+    @Column(name = "aggregate_type", nullable = false, length = 64)
+    private String aggregateType;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(name = "event_key", nullable = false)
+    private String key;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String payload; // JSON
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private OutboxStatus status;
+
+    @Column(nullable = false)
+    private int attempts;
+
+    @Column(name = "next_attempt_at")
+    private OffsetDateTime nextAttemptAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @Column(name = "last_error", length = 500)
+    private String lastError;
+
+    @PrePersist
+    public void prePersist(){
+        var now = OffsetDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+        if(id==null) id = UUID.randomUUID();
+        if(status==null) status = OutboxStatus.NEW;
+    }
+
+    @PreUpdate
+    public void preUpdate(){
+        updatedAt = OffsetDateTime.now();
+    }
+
+    // getters/setters
+    public UUID getId(){ return id; }
+    public void setId(UUID id){ this.id = id; }
+    public String getAggregateId(){ return aggregateId; }
+    public void setAggregateId(String aggregateId){ this.aggregateId = aggregateId; }
+    public String getAggregateType(){ return aggregateType; }
+    public void setAggregateType(String aggregateType){ this.aggregateType = aggregateType; }
+    public String getTopic(){ return topic; }
+    public void setTopic(String topic){ this.topic = topic; }
+    public String getKey(){ return key; }
+    public void setKey(String key){ this.key = key; }
+    public String getPayload(){ return payload; }
+    public void setPayload(String payload){ this.payload = payload; }
+    public OutboxStatus getStatus(){ return status; }
+    public void setStatus(OutboxStatus status){ this.status = status; }
+    public int getAttempts(){ return attempts; }
+    public void setAttempts(int attempts){ this.attempts = attempts; }
+    public OffsetDateTime getNextAttemptAt(){ return nextAttemptAt; }
+    public void setNextAttemptAt(OffsetDateTime nextAttemptAt){ this.nextAttemptAt = nextAttemptAt; }
+    public OffsetDateTime getCreatedAt(){ return createdAt; }
+    public void setCreatedAt(OffsetDateTime createdAt){ this.createdAt = createdAt; }
+    public OffsetDateTime getUpdatedAt(){ return updatedAt; }
+    public void setUpdatedAt(OffsetDateTime updatedAt){ this.updatedAt = updatedAt; }
+    public String getLastError(){ return lastError; }
+    public void setLastError(String lastError){ this.lastError = lastError; }
+}
+

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxEventRepository.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxEventRepository.java
@@ -14,5 +14,7 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> 
     List<OutboxEvent> findBatchDue(@Param("now") OffsetDateTime now, @Param("limit") int limit);
 
     long countByStatus(OutboxStatus status);
-}
 
+    @Query("select min(e.createdAt) from OutboxEvent e where e.status in :statuses")
+    OffsetDateTime findOldestCreatedAtForStatuses(@Param("statuses") List<OutboxStatus> statuses);
+}

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxEventRepository.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxEventRepository.java
@@ -1,0 +1,18 @@
+package com.minicommerce.orders.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+    @Query(value = "SELECT * FROM outbox_events WHERE status IN ('NEW','RETRY') AND (next_attempt_at IS NULL OR next_attempt_at <= :now) ORDER BY created_at ASC LIMIT :limit FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    List<OutboxEvent> findBatchDue(@Param("now") OffsetDateTime now, @Param("limit") int limit);
+
+    long countByStatus(OutboxStatus status);
+}
+

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxHealthIndicator.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxHealthIndicator.java
@@ -1,0 +1,32 @@
+package com.minicommerce.orders.outbox;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Component
+public class OutboxHealthIndicator implements HealthIndicator {
+    private final OutboxEventRepository repository;
+
+    public OutboxHealthIndicator(OutboxEventRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Health health() {
+        long pending = repository.countByStatus(OutboxStatus.NEW) + repository.countByStatus(OutboxStatus.RETRY);
+        long failed = repository.countByStatus(OutboxStatus.FAILED);
+        OffsetDateTime oldest = repository.findOldestCreatedAtForStatuses(List.of(OutboxStatus.NEW, OutboxStatus.RETRY));
+        Long oldestAgeSeconds = oldest == null ? 0L : Duration.between(oldest, OffsetDateTime.now()).getSeconds();
+        Health.Builder builder = failed > 0 ? Health.status("DEGRADED") : Health.up();
+        return builder.withDetail("outbox.pending", pending)
+                .withDetail("outbox.failed", failed)
+                .withDetail("outbox.oldestAgeSeconds", oldestAgeSeconds)
+                .build();
+    }
+}
+

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxProperties.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxProperties.java
@@ -1,0 +1,28 @@
+package com.minicommerce.orders.outbox;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "outbox")
+public class OutboxProperties {
+    /** Batch size for each relay poll */
+    private int batchSize = 50;
+    /** Max publish attempts before marking FAILED */
+    private int maxAttempts = 8;
+    /** Initial backoff in milliseconds */
+    private long initialBackoffMs = 500;
+    /** Exponential multiplier */
+    private double backoffMultiplier = 2.0d;
+    /** Scheduler fixed delay ms */
+    private long relayIntervalMs = 1000;
+
+    public int getBatchSize() { return batchSize; }
+    public void setBatchSize(int batchSize) { this.batchSize = batchSize; }
+    public int getMaxAttempts() { return maxAttempts; }
+    public void setMaxAttempts(int maxAttempts) { this.maxAttempts = maxAttempts; }
+    public long getInitialBackoffMs() { return initialBackoffMs; }
+    public void setInitialBackoffMs(long initialBackoffMs) { this.initialBackoffMs = initialBackoffMs; }
+    public double getBackoffMultiplier() { return backoffMultiplier; }
+    public void setBackoffMultiplier(double backoffMultiplier) { this.backoffMultiplier = backoffMultiplier; }
+    public long getRelayIntervalMs() { return relayIntervalMs; }
+    public void setRelayIntervalMs(long relayIntervalMs) { this.relayIntervalMs = relayIntervalMs; }
+}

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxRelay.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxRelay.java
@@ -3,6 +3,10 @@ package com.minicommerce.orders.outbox;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.minicommerce.orders.events.EventPublisher;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,43 +22,67 @@ public class OutboxRelay {
     private final OutboxProperties properties;
     private final EventPublisher publisher;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
+    private final AtomicLong pendingGauge = new AtomicLong(0);
+    private final AtomicLong failedGauge = new AtomicLong(0);
+    private final AtomicLong oldestAgeGauge = new AtomicLong(0);
 
-    public OutboxRelay(OutboxEventRepository repository, OutboxProperties properties, EventPublisher publisher, ObjectMapper objectMapper) {
+    public OutboxRelay(OutboxEventRepository repository, OutboxProperties properties, EventPublisher publisher, ObjectMapper objectMapper, MeterRegistry meterRegistry) {
         this.repository = repository;
         this.properties = properties;
         this.publisher = publisher;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
+        meterRegistry.gauge("orders.outbox.pending", pendingGauge);
+        meterRegistry.gauge("orders.outbox.failed", failedGauge);
+        meterRegistry.gauge("orders.outbox.backlog.oldest_age_seconds", oldestAgeGauge);
     }
 
     @Scheduled(fixedDelayString = "${outbox.relay-interval-ms:1000}")
     @Transactional
     public void dispatchDueEvents() {
+        Timer.Sample sample = Timer.start(meterRegistry);
         var due = repository.findBatchDue(OffsetDateTime.now(), properties.getBatchSize());
-        if (due.isEmpty()) {
-            return;
-        }
-        for (var row : due) {
-            try {
-                Object payloadToSend;
+        if (!due.isEmpty()) {
+            for (var row : due) {
                 try {
-                    payloadToSend = objectMapper.readValue(row.getPayload(), JsonNode.class);
-                } catch (Exception parseEx) {
-                    log.warn("Failed to parse stored outbox JSON, sending raw string topic={} key={}", row.getTopic(), row.getKey());
-                    payloadToSend = row.getPayload();
+                    Object payloadToSend;
+                    try {
+                        payloadToSend = objectMapper.readValue(row.getPayload(), JsonNode.class);
+                    } catch (Exception parseEx) {
+                        log.warn("Failed to parse stored outbox JSON, sending raw string topic={} key={}", row.getTopic(), row.getKey());
+                        payloadToSend = row.getPayload();
+                    }
+                    publisher.publish(row.getTopic(), row.getKey(), payloadToSend);
+                    row.setStatus(OutboxStatus.SENT);
+                    meterRegistry.counter("orders.outbox.publish.attempt", "status", "success").increment();
+                } catch (Exception e) {
+                    int attempt = row.getAttempts() + 1;
+                    row.setAttempts(attempt);
+                    boolean overMax = attempt >= properties.getMaxAttempts();
+                    row.setStatus(overMax ? OutboxStatus.FAILED : OutboxStatus.RETRY);
+                    long backoff = (long) (properties.getInitialBackoffMs() * Math.pow(properties.getBackoffMultiplier(), Math.max(0, attempt - 1)));
+                    row.setNextAttemptAt(OffsetDateTime.now().plusNanos(backoff * 1_000_000));
+                    row.setLastError(e.getMessage());
+                    meterRegistry.counter("orders.outbox.publish.attempt", "status", "failure").increment();
+                    log.warn("Outbox publish failure topic={} key={} attempt={} status={}: {}", row.getTopic(), row.getKey(), attempt, row.getStatus(), e.getMessage());
                 }
-                publisher.publish(row.getTopic(), row.getKey(), payloadToSend);
-                row.setStatus(OutboxStatus.SENT);
-            } catch (Exception e) {
-                int attempt = row.getAttempts() + 1;
-                row.setAttempts(attempt);
-                boolean overMax = attempt >= properties.getMaxAttempts();
-                row.setStatus(overMax ? OutboxStatus.FAILED : OutboxStatus.RETRY);
-                long backoff = (long) (properties.getInitialBackoffMs() * Math.pow(properties.getBackoffMultiplier(), Math.max(0, attempt - 1)));
-                row.setNextAttemptAt(OffsetDateTime.now().plusNanos(backoff * 1_000_000));
-                row.setLastError(e.getMessage());
-                log.warn("Outbox publish failure topic={} key={} attempt={} status={}: {}", row.getTopic(), row.getKey(), attempt, row.getStatus(), e.getMessage());
             }
         }
+        sample.stop(meterRegistry.timer("orders.outbox.relay.batch.duration"));
+        refreshGauges();
+    }
+
+    private void refreshGauges() {
+        long pending = repository.countByStatus(OutboxStatus.NEW) + repository.countByStatus(OutboxStatus.RETRY);
+        long failed = repository.countByStatus(OutboxStatus.FAILED);
+        var oldest = repository.findOldestCreatedAtForStatuses(List.of(OutboxStatus.NEW, OutboxStatus.RETRY));
+        long oldestAgeSeconds = 0;
+        if (oldest != null) {
+            oldestAgeSeconds = java.time.Duration.between(oldest, OffsetDateTime.now()).getSeconds();
+        }
+        pendingGauge.set(pending);
+        failedGauge.set(failed);
+        oldestAgeGauge.set(oldestAgeSeconds);
     }
 }
-

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxRelay.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxRelay.java
@@ -1,0 +1,60 @@
+package com.minicommerce.orders.outbox;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.minicommerce.orders.events.EventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+@Component
+public class OutboxRelay {
+    private static final Logger log = LoggerFactory.getLogger(OutboxRelay.class);
+    private final OutboxEventRepository repository;
+    private final OutboxProperties properties;
+    private final EventPublisher publisher;
+    private final ObjectMapper objectMapper;
+
+    public OutboxRelay(OutboxEventRepository repository, OutboxProperties properties, EventPublisher publisher, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.properties = properties;
+        this.publisher = publisher;
+        this.objectMapper = objectMapper;
+    }
+
+    @Scheduled(fixedDelayString = "${outbox.relay-interval-ms:1000}")
+    @Transactional
+    public void dispatchDueEvents() {
+        var due = repository.findBatchDue(OffsetDateTime.now(), properties.getBatchSize());
+        if (due.isEmpty()) {
+            return;
+        }
+        for (var row : due) {
+            try {
+                Object payloadToSend;
+                try {
+                    payloadToSend = objectMapper.readValue(row.getPayload(), JsonNode.class);
+                } catch (Exception parseEx) {
+                    log.warn("Failed to parse stored outbox JSON, sending raw string topic={} key={}", row.getTopic(), row.getKey());
+                    payloadToSend = row.getPayload();
+                }
+                publisher.publish(row.getTopic(), row.getKey(), payloadToSend);
+                row.setStatus(OutboxStatus.SENT);
+            } catch (Exception e) {
+                int attempt = row.getAttempts() + 1;
+                row.setAttempts(attempt);
+                boolean overMax = attempt >= properties.getMaxAttempts();
+                row.setStatus(overMax ? OutboxStatus.FAILED : OutboxStatus.RETRY);
+                long backoff = (long) (properties.getInitialBackoffMs() * Math.pow(properties.getBackoffMultiplier(), Math.max(0, attempt - 1)));
+                row.setNextAttemptAt(OffsetDateTime.now().plusNanos(backoff * 1_000_000));
+                row.setLastError(e.getMessage());
+                log.warn("Outbox publish failure topic={} key={} attempt={} status={}: {}", row.getTopic(), row.getKey(), attempt, row.getStatus(), e.getMessage());
+            }
+        }
+    }
+}
+

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxService.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxService.java
@@ -1,0 +1,48 @@
+package com.minicommerce.orders.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.minicommerce.orders.events.EventEnvelope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Persists serialized event envelopes into the outbox table inside the same DB transaction
+ * as the aggregate state change.
+ */
+@Service
+public class OutboxService {
+    private static final Logger log = LoggerFactory.getLogger(OutboxService.class);
+    private final OutboxEventRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    public OutboxService(OutboxEventRepository outboxRepository, ObjectMapper objectMapper) {
+        this.outboxRepository = outboxRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public void persistEvent(String topic,
+                              String messageKey,
+                              String aggregateType,
+                              String aggregateId,
+                              EventEnvelope<?> envelope) {
+        try {
+            var serialized = objectMapper.writeValueAsString(envelope);
+            OutboxEvent row = new OutboxEvent();
+            row.setAggregateId(aggregateId);
+            row.setAggregateType(aggregateType);
+            row.setTopic(topic);
+            row.setKey(messageKey);
+            row.setPayload(serialized);
+            row.setStatus(OutboxStatus.NEW);
+            row.setAttempts(0);
+            outboxRepository.save(row);
+        } catch (Exception e) {
+            log.error("Failed to serialize envelope for topic={} key={} : {}", topic, messageKey, e.getMessage(), e);
+            throw new IllegalStateException("Failed to persist outbox event", e);
+        }
+    }
+}
+

--- a/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxStatus.java
+++ b/order-service/src/main/java/com/minicommerce/orders/outbox/OutboxStatus.java
@@ -1,0 +1,6 @@
+package com.minicommerce.orders.outbox;
+
+public enum OutboxStatus {
+    NEW, RETRY, SENT, FAILED
+}
+

--- a/order-service/src/main/java/com/minicommerce/orders/web/OutboxAdminController.java
+++ b/order-service/src/main/java/com/minicommerce/orders/web/OutboxAdminController.java
@@ -1,0 +1,32 @@
+package com.minicommerce.orders.web;
+
+import com.minicommerce.orders.outbox.OutboxService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/outbox")
+public class OutboxAdminController {
+    private final OutboxService outboxService;
+
+    public OutboxAdminController(OutboxService outboxService) {
+        this.outboxService = outboxService;
+    }
+
+    @PostMapping("/requeue-failed")
+    public Map<String, Object> requeueFailed() {
+        int count = outboxService.requeueFailed();
+        return Map.of("requeued", count);
+    }
+
+    @PostMapping("/{id}/requeue")
+    public ResponseEntity<?> requeueSingle(@PathVariable UUID id) {
+        boolean ok = outboxService.requeueSingle(id);
+        if (ok) return ResponseEntity.ok(Map.of("requeued", id));
+        return ResponseEntity.notFound().build();
+    }
+}
+

--- a/order-service/src/main/resources/db/migration/V2__outbox.sql
+++ b/order-service/src/main/resources/db/migration/V2__outbox.sql
@@ -1,0 +1,19 @@
+-- V2__outbox.sql
+-- Transactional outbox table for reliable event publishing
+CREATE TABLE IF NOT EXISTS public.outbox_events (
+    id              UUID PRIMARY KEY,
+    aggregate_id    TEXT NOT NULL,
+    aggregate_type  VARCHAR(64) NOT NULL,
+    topic           TEXT NOT NULL,
+    event_key       TEXT NOT NULL,
+    payload         TEXT NOT NULL,
+    status          VARCHAR(16) NOT NULL,
+    attempts        INT NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_error      TEXT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_status_due ON public.outbox_events(status, next_attempt_at);
+

--- a/order-service/src/main/resources/openapi/order-service.yaml
+++ b/order-service/src/main/resources/openapi/order-service.yaml
@@ -103,6 +103,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
+  /api/v1/outbox/requeue-failed:
+    post:
+      tags: [Outbox]
+      summary: Requeue all FAILED outbox events
+      operationId: requeueFailedOutboxEvents
+      responses:
+        '200':
+          description: Count of requeued events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequeueFailedResponse'
+  /api/v1/outbox/{id}/requeue:
+    post:
+      tags: [Outbox]
+      summary: Requeue a single FAILED outbox event by id
+      operationId: requeueSingleOutboxEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Event requeued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequeueSingleResponse'
+        '404':
+          description: Event not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
 components:
   schemas:
     CreateOrderRequest:
@@ -118,11 +153,11 @@ components:
             $ref: '#/components/schemas/OrderItemRequest'
     OrderItemRequest:
       type: object
-      required: [sku, name, qty, unitPrice]
+      required: [sku, name, quantity, unitPrice]
       properties:
         sku: { type: string }
         name: { type: string }
-        qty: { type: integer, minimum: 1 }
+        quantity: { type: integer, minimum: 1 }
         unitPrice: { type: number, format: double, minimum: 0 }
     OrderResponse:
       type: object
@@ -144,7 +179,7 @@ components:
         id: { type: string, format: uuid }
         sku: { type: string }
         name: { type: string }
-        qty: { type: integer }
+        quantity: { type: integer }
         unitPrice: { type: number, format: double }
         lineTotal: { type: number, format: double }
     ApiError:
@@ -166,3 +201,11 @@ components:
         size: { type: integer }
         totalElements: { type: integer }
         totalPages: { type: integer }
+    RequeueFailedResponse:
+      type: object
+      properties:
+        requeued: { type: integer, minimum: 0 }
+    RequeueSingleResponse:
+      type: object
+      properties:
+        requeued: { type: string, format: uuid }

--- a/order-service/src/test/java/com/minicommerce/orders/OrderIntegrationTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/OrderIntegrationTest.java
@@ -92,9 +92,10 @@ class OrderIntegrationTest {
             ConsumerRecord<String, String> createdEvent = pollForEvent(consumer, Topics.ORDER_CREATED, order.id().toString());
             Assertions.assertNotNull(createdEvent, "ORDER_CREATED event not received");
             JsonNode createdJson = mapper.readTree(createdEvent.value());
-            Assertions.assertEquals(order.id().toString(), createdJson.get("orderId").asText());
             Assertions.assertEquals("order.created", createdJson.get("type").asText());
+            Assertions.assertEquals(order.id().toString(), createdJson.get("data").get("orderId").asText());
 
+            // cancel
             ResponseEntity<OrderResponse> cancelled = http.exchange(
                     "/api/v1/orders/{id}/cancel", HttpMethod.PATCH, HttpEntity.EMPTY, OrderResponse.class,
                     Map.of("id", order.id())
@@ -105,8 +106,8 @@ class OrderIntegrationTest {
             ConsumerRecord<String, String> cancelledEvent = pollForEvent(consumer, Topics.ORDER_CANCELLED, order.id().toString());
             Assertions.assertNotNull(cancelledEvent, "ORDER_CANCELLED event not received");
             JsonNode cancelledJson = mapper.readTree(cancelledEvent.value());
-            Assertions.assertEquals(order.id().toString(), cancelledJson.get("orderId").asText());
             Assertions.assertEquals("order.cancelled", cancelledJson.get("type").asText());
+            Assertions.assertEquals(order.id().toString(), cancelledJson.get("data").get("orderId").asText());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/order-service/src/test/java/com/minicommerce/orders/concurrency/CancelOptimisticLockTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/concurrency/CancelOptimisticLockTest.java
@@ -1,0 +1,86 @@
+package com.minicommerce.orders.concurrency;
+
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.service.OrderService;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+@SpringBootTest
+@Testcontainers
+class CancelOptimisticLockTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        r.add("outbox.relay-interval-ms", () -> "500");
+    }
+
+    @Autowired OrderService orderService;
+    @Autowired OrderRepository orderRepository;
+
+    UUID orderId;
+
+    @BeforeEach
+    void setup(){
+        orderRepository.deleteAll();
+        var order = orderService.create(new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(
+                new OrderItemRequest("SKU-C", "Mouse", 1, new BigDecimal("10.00"))
+        )));
+        orderId = order.getId();
+    }
+
+    @Test
+    void second_cancel_attempt_hits_optimistic_lock() throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Callable<Boolean> task = () -> {
+                try {
+                    orderService.cancel(orderId);
+                    return true;
+                } catch (OptimisticLockingFailureException e){
+                    return false; // expected for one thread
+                }
+            };
+            Future<Boolean> f1 = pool.submit(task);
+            Future<Boolean> f2 = pool.submit(task);
+            boolean r1 = get(f1);
+            boolean r2 = get(f2);
+            org.assertj.core.api.Assertions.assertThat(r1 ^ r2).as("Exactly one cancel should succeed").isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private boolean get(Future<Boolean> f) throws ExecutionException, InterruptedException { return f.get(); }
+}

--- a/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRelayFailureToFailedTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRelayFailureToFailedTest.java
@@ -1,0 +1,88 @@
+package com.minicommerce.orders.outbox;
+
+import com.minicommerce.orders.events.EventPublisher;
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.service.OrderService;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.awaitility.Awaitility.await;
+import java.time.Duration;
+
+@SpringBootTest
+@Testcontainers
+class OutboxRelayFailureToFailedTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        r.add("outbox.relay-interval-ms", () -> "150");
+        r.add("outbox.max-attempts", () -> "2");
+    }
+
+    @TestConfiguration
+    static class FailingPublisherConfig {
+        @Bean
+        @Primary
+        EventPublisher failingPublisher(){
+            return new EventPublisher(null) {
+                @Override
+                public void publish(String topic, String key, Object payload) {
+                    throw new RuntimeException("forced failure");
+                }
+            };
+        }
+    }
+
+    @Autowired OrderService orderService;
+    @Autowired OrderRepository orderRepository;
+    @Autowired OutboxEventRepository outboxRepository;
+
+    @BeforeEach
+    void clean(){
+        outboxRepository.deleteAll();
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void failing_publisher_leads_to_failed_status_after_max_attempts() {
+        orderService.create(new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(
+                new OrderItemRequest("SKU-X", "Mouse", 1, new BigDecimal("10.00"))
+        )));
+        Assertions.assertThat(outboxRepository.count()).isEqualTo(1);
+        await().atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(150))
+                .untilAsserted(() -> {
+                    var row = outboxRepository.findAll().get(0);
+                    Assertions.assertThat(row.getStatus()).isEqualTo(OutboxStatus.FAILED);
+                });
+    }
+}

--- a/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRelayRetryThenSuccessTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRelayRetryThenSuccessTest.java
@@ -1,0 +1,91 @@
+package com.minicommerce.orders.outbox;
+
+import com.minicommerce.orders.events.EventPublisher;
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.service.OrderService;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.awaitility.Awaitility.await;
+import java.time.Duration;
+
+@SpringBootTest
+@Testcontainers
+class OutboxRelayRetryThenSuccessTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        r.add("outbox.relay-interval-ms", () -> "150");
+        r.add("outbox.max-attempts", () -> "4");
+        r.add("outbox.initial-backoff-ms", () -> "50");
+    }
+
+    @TestConfiguration
+    static class FlakyPublisherConfig {
+        @Bean
+        @Primary
+        EventPublisher flakyPublisher(){
+            AtomicInteger counter = new AtomicInteger();
+            return new EventPublisher(null) {
+                @Override
+                public void publish(String topic, String key, Object payload) {
+                    if(counter.getAndIncrement() < 2){
+                        throw new RuntimeException("transient failure");
+                    }
+                    // success after 2 failures
+                }
+            };
+        }
+    }
+
+    @Autowired OrderService orderService;
+    @Autowired OrderRepository orderRepository;
+    @Autowired OutboxEventRepository outboxRepository;
+
+    @BeforeEach
+    void clean(){
+        outboxRepository.deleteAll();
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void transient_failures_eventually_sent() {
+        orderService.create(new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(new OrderItemRequest("SKU-R", "Mouse",1,new BigDecimal("5.00")))));
+        await().atMost(Duration.ofSeconds(6))
+                .pollInterval(Duration.ofMillis(125))
+                .untilAsserted(() -> {
+                    var row = outboxRepository.findAll().get(0);
+                    org.assertj.core.api.Assertions.assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
+                });
+    }
+}

--- a/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRelaySuccessTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRelaySuccessTest.java
@@ -1,0 +1,72 @@
+package com.minicommerce.orders.outbox;
+
+import com.minicommerce.orders.events.Topics;
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.service.OrderService;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest
+@Testcontainers
+class OutboxRelaySuccessTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        r.add("outbox.relay-interval-ms", () -> "200");
+    }
+
+    @Autowired OrderService orderService;
+    @Autowired OrderRepository orderRepository;
+    @Autowired OutboxEventRepository outboxRepository;
+
+    @BeforeEach
+    void clean(){
+        outboxRepository.deleteAll();
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void relay_marks_event_sent() {
+        var req = new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(
+                new OrderItemRequest("SKU-OK", "Mouse", 1, new BigDecimal("10.00"))
+        ));
+        orderService.create(req);
+        Assertions.assertThat(outboxRepository.count()).isEqualTo(1);
+
+        await().atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(150))
+                .untilAsserted(() -> {
+                    var row = outboxRepository.findAll().get(0);
+                    Assertions.assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
+                });
+    }
+}

--- a/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRequeueEndpointTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/outbox/OutboxRequeueEndpointTest.java
@@ -1,0 +1,79 @@
+package com.minicommerce.orders.outbox;
+
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.service.OrderService;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class OutboxRequeueEndpointTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        r.add("outbox.relay-interval-ms", () -> "5000"); // slow relay to avoid races
+    }
+
+    @Autowired OrderService orderService;
+    @Autowired OrderRepository orderRepository;
+    @Autowired OutboxEventRepository outboxRepository;
+    @Autowired TestRestTemplate rest;
+
+    @BeforeEach
+    void clean(){
+        outboxRepository.deleteAll();
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void requeue_failed_endpoint_resets_failed_rows() {
+        // create order -> NEW outbox row
+        orderService.create(new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(
+                new OrderItemRequest("SKU-RQ", "Mouse", 1, new BigDecimal("11.00"))
+        )));
+        var row = outboxRepository.findAll().get(0);
+        // force FAILED state
+        row.setStatus(OutboxStatus.FAILED);
+        row.setAttempts(3);
+        row.setLastError("forced");
+        outboxRepository.save(row);
+
+        ResponseEntity<Map> resp = rest.exchange("/api/v1/outbox/requeue-failed", HttpMethod.POST, null, Map.class);
+        Assertions.assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        var updated = outboxRepository.findAll().get(0);
+        Assertions.assertThat(updated.getStatus()).isEqualTo(OutboxStatus.RETRY);
+        Assertions.assertThat(updated.getAttempts()).isZero();
+        Assertions.assertThat(updated.getLastError()).isNull();
+    }
+}
+

--- a/order-service/src/test/java/com/minicommerce/orders/schema/OrderCancelledSchemaValidationTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/schema/OrderCancelledSchemaValidationTest.java
@@ -1,0 +1,89 @@
+package com.minicommerce.orders.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.minicommerce.orders.outbox.OutboxEventRepository;
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.service.OrderService;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@SpringBootTest
+@Testcontainers
+class OrderCancelledSchemaValidationTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        r.add("outbox.relay-interval-ms", () -> "250");
+    }
+
+    @Autowired OrderService orderService;
+    @Autowired OrderRepository orderRepository;
+    @Autowired OutboxEventRepository outboxRepository;
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void clean(){
+        outboxRepository.deleteAll();
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void cancelled_event_matches_schema() throws Exception {
+        var order = orderService.create(new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(
+                new OrderItemRequest("SKU-Z", "Mouse", 1, new BigDecimal("4.25"))
+        )));
+        orderService.cancel(order.getId());
+        Assertions.assertThat(outboxRepository.count()).isEqualTo(2);
+        var cancelledRow = outboxRepository.findAll().stream()
+                .filter(r -> {
+                    try { return mapper.readTree(r.getPayload()).get("type").asText().equals("order.cancelled"); }
+                    catch (Exception e){ return false; }
+                })
+                .findFirst().orElseThrow();
+        JsonNode payload = mapper.readTree(cancelledRow.getPayload());
+        Path schemaPath = Path.of("..", "docs", "api", "events", "order.cancelled.v1.json");
+        try (InputStream in = Files.newInputStream(schemaPath)) {
+            JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+            JsonSchema schema = factory.getSchema(in);
+            Set<ValidationMessage> errors = schema.validate(payload);
+            Assertions.assertThat(errors).isEmpty();
+        }
+    }
+}
+

--- a/order-service/src/test/java/com/minicommerce/orders/schema/OrderCreatedSchemaValidationTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/schema/OrderCreatedSchemaValidationTest.java
@@ -1,0 +1,83 @@
+package com.minicommerce.orders.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.minicommerce.orders.outbox.OutboxEventRepository;
+import com.minicommerce.orders.repository.OrderRepository;
+import com.minicommerce.orders.service.OrderService;
+import com.minicommerce.orders.web.dto.CreateOrderRequest;
+import com.minicommerce.orders.web.dto.OrderItemRequest;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.math.BigDecimal;
+import java.util.Set;
+
+@SpringBootTest
+@Testcontainers
+class OrderCreatedSchemaValidationTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        r.add("outbox.relay-interval-ms", () -> "250");
+    }
+
+    @Autowired OrderService orderService;
+    @Autowired OrderRepository orderRepository;
+    @Autowired OutboxEventRepository outboxRepository;
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void clean(){
+        outboxRepository.deleteAll();
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void created_event_matches_schema() throws Exception {
+        orderService.create(new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(
+                new OrderItemRequest("SKU-S", "Mouse", 1, new BigDecimal("7.50"))
+        )));
+        var row = outboxRepository.findAll().get(0);
+        JsonNode payload = mapper.readTree(row.getPayload());
+
+        Path schemaPath = Path.of("..", "docs", "api", "events", "order.created.v1.json");
+        try (InputStream in = Files.newInputStream(schemaPath)) {
+            JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+            JsonSchema schema = factory.getSchema(in);
+            Set<ValidationMessage> errors = schema.validate(payload);
+            Assertions.assertThat(errors).as("Schema violations" + errors).isEmpty();
+        }
+    }
+}
+

--- a/order-service/src/test/java/com/minicommerce/orders/service/OrderServiceEventPublishingTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/service/OrderServiceEventPublishingTest.java
@@ -1,32 +1,29 @@
 package com.minicommerce.orders.service;
 
-import com.minicommerce.orders.events.EventPublisher;
-import com.minicommerce.orders.events.OrderCreatedEvent;
-import com.minicommerce.orders.events.Topics;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.minicommerce.orders.outbox.OutboxEventRepository;
+import com.minicommerce.orders.outbox.OutboxStatus;
 import com.minicommerce.orders.repository.OrderRepository;
 import com.minicommerce.orders.web.dto.CreateOrderRequest;
 import com.minicommerce.orders.web.dto.OrderItemRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Testcontainers
@@ -36,6 +33,13 @@ class OrderServiceEventPublishingTest {
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
     @Container
     static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+    @Autowired
+    OrderService orderService;
+    @Autowired
+    OrderRepository orderRepository;
+    @Autowired
+    OutboxEventRepository outboxRepository;
+    CreateOrderRequest createRequest;
 
     @DynamicPropertySource
     static void datasourceProps(DynamicPropertyRegistry registry) {
@@ -45,60 +49,45 @@ class OrderServiceEventPublishingTest {
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
         registry.add("spring.flyway.enabled", () -> "false");
         registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        // speed up relay for test
+        registry.add("outbox.relay-interval-ms", () -> "500");
     }
-
-    @Autowired
-    OrderService service;
-    @Autowired
-    OrderRepository orders;
-
-    @MockBean
-    EventPublisher publisher;
-
-    CreateOrderRequest request;
 
     @BeforeEach
     void setup() {
-        orders.deleteAll();
-        request = new CreateOrderRequest(
-                UUID.randomUUID(),
-                "USD",
-                List.of(new OrderItemRequest("SKU1", "Mouse", 1, new BigDecimal("10.00")))
-        );
+        outboxRepository.deleteAll();
+        orderRepository.deleteAll();
+        createRequest = new CreateOrderRequest(UUID.randomUUID(), "USD", List.of(new OrderItemRequest("SKU1", "Mouse", 1, new BigDecimal("10.00"))));
     }
 
     @Test
-    void create_publishes_event_after_commit() {
-        service.create(request);
-
-        ArgumentCaptor<OrderCreatedEvent> event = ArgumentCaptor.forClass(OrderCreatedEvent.class);
-        Mockito.verify(publisher).publish(Mockito.eq(Topics.ORDER_CREATED), Mockito.anyString(), event.capture());
-        assertThat(event.getValue().type()).isEqualTo("order.created");
-        assertThat(event.getValue().version()).isEqualTo("v1");
+    void create_persists_outbox_envelope() throws Exception {
+        orderService.create(createRequest);
+        assertThat(orderRepository.count()).isEqualTo(1);
+        var rows = outboxRepository.findAll();
+        assertThat(rows).hasSize(1);
+        var row = rows.get(0);
+        assertThat(row.getStatus()).isEqualTo(OutboxStatus.NEW);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode json = mapper.readTree(row.getPayload());
+        assertThat(json.get("type").asText()).isEqualTo("order.created");
+        assertThat(json.get("data").get("orderId").asText()).isNotBlank();
     }
 
     @Test
-    void create_persists_even_if_event_publish_fails() {
-        Mockito.doThrow(new RuntimeException("kafka down"))
-                .when(publisher).publish(Mockito.anyString(), Mockito.anyString(), Mockito.any());
-
-        // Should NOT throw because afterCommit exceptions are swallowed by Spring
-        service.create(request);
-        assertEquals(1, orders.count());
-        Mockito.verify(publisher).publish(Mockito.eq(Topics.ORDER_CREATED), Mockito.anyString(), Mockito.any());
-    }
-
-    @Test
-    void cancel_publishes_event() {
-        service.create(request);
-        Mockito.reset(publisher);
-
-        var order = orders.findAll().get(0);
-        service.cancel(order.getId());
-
-        Mockito.verify(publisher)
-                .publish(Mockito.eq(Topics.ORDER_CANCELLED),
-                        Mockito.eq(order.getId().toString()),
-                        Mockito.any());
+    void cancel_adds_second_outbox_event() throws Exception {
+        var order = orderService.create(createRequest);
+        orderService.cancel(order.getId());
+        var rows = outboxRepository.findAll();
+        assertThat(rows).hasSize(2);
+        ObjectMapper mapper = new ObjectMapper();
+        long cancelledCount = rows.stream().filter(r -> {
+            try {
+                return mapper.readTree(r.getPayload()).get("type").asText().equals("order.cancelled");
+            } catch (Exception e) {
+                return false;
+            }
+        }).count();
+        assertThat(cancelledCount).isEqualTo(1);
     }
 }

--- a/order-service/src/test/java/com/minicommerce/orders/validation/CreateOrderValidationTest.java
+++ b/order-service/src/test/java/com/minicommerce/orders/validation/CreateOrderValidationTest.java
@@ -1,0 +1,71 @@
+package com.minicommerce.orders.validation;
+
+import com.minicommerce.orders.OrdersApplication;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+import java.util.UUID;
+
+@SpringBootTest(classes = OrdersApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class CreateOrderValidationTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r){
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+        r.add("spring.datasource.username", postgres::getUsername);
+        r.add("spring.datasource.password", postgres::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        r.add("spring.flyway.enabled", () -> "false");
+        r.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+    }
+
+    @Autowired
+    TestRestTemplate rest;
+
+    @Test
+    void rejects_empty_items() {
+        String body = "{" +
+                "\"customerId\":\""+ UUID.randomUUID() +"\"," +
+                "\"currency\":\"USD\"," +
+                "\"items\":[]}"; // invalid: items empty
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Map> response = rest.exchange("/api/v1/orders", HttpMethod.POST, new HttpEntity<>(body, headers), Map.class);
+        Assertions.assertThat(response.getStatusCode().value()).isEqualTo(400);
+    }
+
+    @Test
+    void rejects_invalid_currency_length() {
+        String body = "{" +
+                "\"customerId\":\""+ UUID.randomUUID() +"\"," +
+                "\"currency\":\"US\"," + // too short
+                "\"items\":[{" +
+                "\"sku\":\"S1\",\"name\":\"Mouse\",\"quantity\":1,\"unitPrice\":10.0}]}";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Map> response = rest.exchange("/api/v1/orders", HttpMethod.POST, new HttpEntity<>(body, headers), Map.class);
+        Assertions.assertThat(response.getStatusCode().value()).isEqualTo(400);
+    }
+}
+


### PR DESCRIPTION
## [Unreleased]
### Added
- Transactional outbox implementation (entity, repository, relay with exponential backoff & retry)
- Event envelope (eventId, type, version, occurredAt, aggregateType, aggregateId, traceId, data)
- Micrometer metrics for outbox: `orders.outbox.pending`, `orders.outbox.failed`, `orders.outbox.backlog.oldest_age_seconds`, `orders.outbox.relay.batch.duration`, `orders.outbox.publish.attempt{status}`
- Health indicator (DEGRADED on failed rows) surfaced via `/actuator/health`
- Admin endpoints: `POST /api/v1/outbox/requeue-failed`, `POST /api/v1/outbox/{id}/requeue`
- Comprehensive test suite (relay success, retry -> success, forced failure -> FAILED, schema validation, optimistic locking, validation errors, requeue endpoint)
- JSON Schema validation tests for `order.created.v1` & `order.cancelled.v1`
- Awaitility-based polling in async integration tests
- README enhancements (event envelope example, metrics, health, admin endpoints, CI badge)
- OpenAPI spec updates (outbox endpoints, quantity field normalization)
- Flyway migration `V2__outbox.sql` (if Flyway enabled) for outbox table

### Changed
- Removed afterCommit direct Kafka publishing in favor of transactional outbox persistence
- Simplified `EventPublisher` (single-attempt publish)
- Refactored event payload classes to domain-only (moved type/version to envelope)
- Improved domain model with `@Version` and lifecycle timestamp callbacks

### Fixed / Hardening
- Increased reliability & visibility for event publishing failures
- Added validation & optimistic locking test coverage

### Security / Observability
- Structured logging for publish failures (attempt, status)
- Outbox backlog and failure counts exposed via metrics & health

### Deprecated
- (None)

### Removed
- Legacy afterCommit event publishing logic

### Breaking Changes
- Event JSON shape changed (type/version now at envelope root; legacy consumers may need adaptation)
